### PR TITLE
left join instead of inner join

### DIFF
--- a/R/oracle_merge_strings.R
+++ b/R/oracle_merge_strings.R
@@ -92,5 +92,5 @@ oracle_merge_strings <- function(df, first_col, second_col, merge_col) {
 
   # Output the original data with the merged string joined to it
   df %>%
-    dplyr::inner_join(y = merged_df)
+    dplyr::left_join(y = merged_df)
 }


### PR DESCRIPTION
changed inner join to left join

This is only ever used when merging DPA and GEO SLA.

Compare with the original function to see the inner_join 'losing' records